### PR TITLE
Make relative URLs absolute inside src and href attributes

### DIFF
--- a/views/form-user-profile.phtml
+++ b/views/form-user-profile.phtml
@@ -8,7 +8,7 @@
 			if ($data->medium_user->token) {
 				?><p class="description">Connected to Medium as <a href="<?= $data->medium_user->url ?>"><?= $data->medium_user->name ?></a>.</p><?php
 			} else {
-				?><p class="description">You can get this from the Integration Tokens section of your <a href="https://medium.com/me/settings#integration-tokens">Medium Settings</a>.</p><?php
+				?><p class="description">You can get this from the Integration Tokens section of your <a href="https://medium.com/me/settings#integration-tokens" target="_blank">Medium Settings</a>.</p><?php
 			}
 			?>
 		</td>


### PR DESCRIPTION
Hello @majelbstoat, @kylehg, 

Please review the following commits I made in branch 'jamie-relative-images'.

57181712a9526aff8720aeb22350fd9f85ad8d85 (2015-10-03 16:32:48 -0700)
Make relative URLs absolute inside src and href attributes

R=@majelbstoat
R=@kylehg

MANUAL TESTING=bunch of testing of relative and absolute urls

Code review reminders. By giving a LGTM you attest that: 
- Commits are adequately tested 
- Code is easy to understand and conforms to our [style guides](https://github.com/Medium/docs/tree/master/style-guide) 
- Incomplete code is marked with TODOs 
- Logging and metrics are suitable 
