### PR TITLE
Still show the avatar and url of a post author even after disconnection

### DIFF
--- a/lib/medium-admin.php
+++ b/lib/medium-admin.php
@@ -173,6 +173,8 @@ class Medium_Admin {
 
     $medium_post->id = $created_medium_post->id;
     $medium_post->url = $created_medium_post->url;
+    $medium_post->author_image_url = $medium_user->image_url;
+    $medium_post->author_url = $medium_user->url;
     $medium_post->save($post_id);
 
     self::_add_notice("published", array(
@@ -192,12 +194,15 @@ class Medium_Admin {
 
     $medium_logo_url = MEDIUM_PLUGIN_URL . 'i/logo.png';
     $medium_post = Medium_Post::get_by_wp_id($post->ID);
-    $medium_user = Medium_User::get_by_wp_id($current_user->ID);
+    $medium_user = Medium_User::get_by_wp_id($post->post_author);
     if ($medium_post->id) {
       // Already connected.
+      if ($medium_user->id) {
+        $medium_post->author_url = $medium_user->url;
+        $medium_post->author_image_url = $medium_user->image_url;
+      }
       Medium_View::render("form-post-box-linked", array(
         "medium_post" => $medium_post,
-        "medium_user" => $medium_user,
         "medium_logo_url" => $medium_logo_url
       ));
     } else if ($medium_user->token && $medium_user->id) {

--- a/lib/medium-post.php
+++ b/lib/medium-post.php
@@ -6,6 +6,8 @@
  * Representation of a Medium post.
  */
 class Medium_Post {
+  public $author_image_url;
+  public $author_url;
   public $cross_link;
   public $id;
   public $license;

--- a/views/form-post-box-linked.phtml
+++ b/views/form-post-box-linked.phtml
@@ -1,7 +1,7 @@
 <div class="misc-pub-section misc-pub-medium-status">
 	<div class="post-medium-images">
 		<a href="https://medium.com"><img class="post-medium-image post-medium-image-logo" src="<?= $data->medium_logo_url ?>"/></a>
-		<a href="<?= $data->medium_user->url ?>"><img class="post-medium-image post-medium-image-avatar" src="<?= $data->medium_user->image_url ?>"/></a>
+		<a href="<?= $data->medium_post->author_url ?>"><img class="post-medium-image post-medium-image-avatar" src="<?= $data->medium_post->author_image_url ?>"/></a>
 	</div>
 	<div id="medium-post-link">
 		<b><a href="<?= $data->medium_post->url ?>" target="_blank">View Medium post</a></b>


### PR DESCRIPTION
Hello @majelbstoat, 

Please review the following commits I made in branch 'jamie-post-user'.

5750b6c320d1863e80212db0004973e3187c8540 (2015-10-04 19:35:28 -0700)
Still show the avatar and url of a post author even after disconnection

R=@majelbstoat

MANUAL TESTING=manually tested

Code review reminders. By giving a LGTM you attest that: 
- Commits are adequately tested 
- Code is easy to understand and conforms to our [style guides](https://github.com/Medium/docs/tree/master/style-guide) 
- Incomplete code is marked with TODOs 
- Logging and metrics are suitable 
