### PR TITLE
Use makefile to generate zip archive

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+all:
+	@echo "make zip - Create medium.zip"
+
+zip:
+	rm medium.zip
+	zip -rT medium.zip ./*
+
+


### PR DESCRIPTION
Current medium.zip doesn't contain the full plug-in files (see https://github.com/Medium/medium-wordpress-plugin/issues/9). 

Use "make zip" with this Makefile to generate it (or, as suggested in the issue, just remove the zip and let people create zip from github)

HTH