### PR TITLE
Make strings in views i18n compat

### DIFF
--- a/views/content-cross-linked.phtml
+++ b/views/content-cross-linked.phtml
@@ -4,7 +4,7 @@
 	<em>
 		<?php
 		printf(
-			_x( 'Also published on %s.', 'medium', 'Medium post link' ),
+			_x( 'Also published on %s.', 'Medium post link', 'medium' ),
 			sprintf(
 				'<a href="%s">%s</a>',
 				esc_url( $data->medium_post->url ),

--- a/views/content-cross-linked.phtml
+++ b/views/content-cross-linked.phtml
@@ -1,3 +1,16 @@
 <?= $data->content ?>
 <hr>
-<p><em>Also published on <a href="<?= $data->medium_post->url ?>">Medium</a>.</em></p>
+<p>
+	<em>
+		<?php
+		printf(
+			_x( 'Also published on %s.', 'medium', 'Medium post link' ),
+			sprintf(
+				'<a href="%s">%s</a>',
+				esc_url( $data->medium_post->url ),
+				__( 'Medium', 'medium' )
+			)
+		)
+		?>
+	</em>
+</p>

--- a/views/content-rendered-post.phtml
+++ b/views/content-rendered-post.phtml
@@ -1,9 +1,19 @@
 <h1><?= $data->title ?></h1>
 <?= $data->content ?>
-<?php
-if ($data->cross_link) {
-	?>
+<?php if ( $data->cross_link ) : ?>
 	<hr>
-	<p><em>Originally published at <a href="<?= $data->permalink ?>"><?= $data->site_name ?></a>.</em></p>
-	<?php
-}
+	<p>
+		<em>
+			<?php
+			printf(
+				_x( 'Originally published at %s.', 'medium', 'WordPress post permalink' ),
+				sprintf(
+					'<a href="%s">%s</a>',
+					esc_url( $data->permalink ),
+					esc_html( $data->site_name )
+				)
+			)
+			?>
+		</em>
+	</p>
+<?php endif; ?>

--- a/views/content-rendered-post.phtml
+++ b/views/content-rendered-post.phtml
@@ -6,7 +6,7 @@
 		<em>
 			<?php
 			printf(
-				_x( 'Originally published at %s.', 'medium', 'WordPress post permalink' ),
+				_x( 'Originally published at %s.', 'WordPress post permalink', 'medium' ),
 				sprintf(
 					'<a href="%s">%s</a>',
 					esc_url( $data->permalink ),

--- a/views/form-post-box-actions-disabled.phtml
+++ b/views/form-post-box-actions-disabled.phtml
@@ -1,3 +1,14 @@
 <div class="misc-pub-section misc-pub-medium-status">
-  <span>Add an integration token on <a href="<?= $data->edit_profile_url ?>">your profile page</a> to enable cross-posting to Medium.</span>
+	<span>
+		<?php
+		printf(
+			_x( 'Add an integration token on %s to enable cross-posting to Medium.', 'medium', 'Medium user profile link' ),
+			sprintf(
+				'<a href="%s">%s</a>',
+				esc_url( $data->edit_profile_url ),
+				__( 'your profile page', 'medium' )
+			)
+		)
+		?>
+	</span>
 </div>

--- a/views/form-post-box-actions-disabled.phtml
+++ b/views/form-post-box-actions-disabled.phtml
@@ -2,7 +2,7 @@
 	<span>
 		<?php
 		printf(
-			_x( 'Add an integration token on %s to enable cross-posting to Medium.', 'medium', 'Medium user profile link' ),
+			_x( 'Add an integration token on %s to enable cross-posting to Medium.', 'Medium user profile link', 'medium' ),
 			sprintf(
 				'<a href="%s">%s</a>',
 				esc_url( $data->edit_profile_url ),

--- a/views/form-post-box-actions.phtml
+++ b/views/form-post-box-actions.phtml
@@ -3,10 +3,10 @@
 		<a href="<?= $data->medium_user->url ?>"><img class="post-medium-image post-medium-image-avatar" src="<?= $data->medium_user->image_url ?>"/></a>
 		<a href="https://medium.com"><img class="post-medium-image post-medium-image-logo" src="<?= $data->medium_logo_url ?>"/></a>
 	</div>
-	<span id="medium-status">Crosspost as: <b><span id="post-medium-status-display"><?= $data->medium_post_statuses[$data->medium_post->status] ?></span></b>
+	<span id="medium-status"><?php _e( 'Crosspost as:', 'medium' ) ?> <b><span id="post-medium-status-display"><?= $data->medium_post_statuses[$data->medium_post->status] ?></span></b>
 		<a href="#edit_medium_status" class="edit-medium-status hide-if-no-js">
-			<span aria-hidden="true">Edit</span>
-			<span class="screen-reader-text">Edit Crosspost option</span>
+			<span aria-hidden="true"><?php _e( 'Edit', 'medium' ) ?></span>
+			<span class="screen-reader-text"><?php _e( 'Edit Crosspost option', 'medium' ) ?></span>
 		</a>
 	</span>
 
@@ -21,17 +21,17 @@
 		}
 		?>
 		<p>
-		 <a href="#medium-status" class="save-post-medium-status hide-if-no-js button"><?= __('OK'); ?></a>
-		 <a href="#medium-status" class="cancel-post-medium-status hide-if-no-js button-cancel"><?= __('Cancel'); ?></a>
+		 <a href="#medium-status" class="save-post-medium-status hide-if-no-js button"><?php _e( 'OK', 'medium' ) ?></a>
+		 <a href="#medium-status" class="cancel-post-medium-status hide-if-no-js button-cancel"><?php _e( 'Cancel', 'medium' ) ?></a>
 		</p>
 	</div>
 </div>
 
 <div class="misc-pub-section misc-pub-medium-license <?= $data->options_visibility_class ?>">
-	<span id="medium-license">License: <b><span id="post-medium-license-display"><?= $data->medium_post_licenses[$data->medium_post->license] ?></span></b>
+	<span id="medium-license"><?php _e( 'License:', 'medium' ) ?> <b><span id="post-medium-license-display"><?= $data->medium_post_licenses[$data->medium_post->license] ?></span></b>
 		<a href="#edit_medium_license" class="edit-medium-license hide-if-no-js">
-			<span aria-hidden="true">Edit</span>
-			<span class="screen-reader-text">Edit Medium license</span>
+			<span aria-hidden="true"><?php _e( 'Edit', 'medium' ) ?></span>
+			<span class="screen-reader-text"><?php _e( 'Edit Medium license', 'medium' ) ?></span>
 		</a>
 	</span>
 
@@ -46,17 +46,17 @@
 		}
 		?>
 		<p>
-		 <a href="#medium-license" class="save-post-medium-license hide-if-no-js button"><?= __('OK'); ?></a>
-		 <a href="#medium-license" class="cancel-post-medium-license hide-if-no-js button-cancel"><?= __('Cancel'); ?></a>
+		 <a href="#medium-license" class="save-post-medium-license hide-if-no-js button"><?php _e( 'OK', 'medium' ) ?></a>
+		 <a href="#medium-license" class="cancel-post-medium-license hide-if-no-js button-cancel"><?php _e( 'Cancel', 'medium' ) ?></a>
 		</p>
 	</div>
 </div>
 
 <div class="misc-pub-section misc-pub-medium-cross-link <?= $data->options_visibility_class ?>">
-	<span id="medium-cross-link">Cross-link posts: <b><span id="post-medium-cross-link-display"><?= $data->medium_post_cross_link_options[$data->medium_post->cross_link] ?></span></b>
+	<span id="medium-cross-link"><?php _e( 'Cross-link posts:', 'medium' ) ?> <b><span id="post-medium-cross-link-display"><?= $data->medium_post_cross_link_options[$data->medium_post->cross_link] ?></span></b>
 		<a href="#edit_medium_cross_link" class="edit-medium-cross-link hide-if-no-js">
-			<span aria-hidden="true">Edit</span>
-			<span class="screen-reader-text">Edit cross-link status</span>
+			<span aria-hidden="true"><?php _e( 'Edit', 'medium' ) ?></span>
+			<span class="screen-reader-text"><?php _e( 'Edit cross-link status', 'medium' ) ?></span>
 		</a>
 	</span>
 
@@ -71,8 +71,8 @@
 		}
 		?>
 		<p>
-		 <a href="#medium-cross-link" class="save-post-medium-cross-link hide-if-no-js button"><?= __('OK'); ?></a>
-		 <a href="#medium-cross-link" class="cancel-post-medium-cross-link hide-if-no-js button-cancel"><?= __('Cancel'); ?></a>
+		 <a href="#medium-cross-link" class="save-post-medium-cross-link hide-if-no-js button"><?php _e( 'OK', 'medium' ) ?></a>
+		 <a href="#medium-cross-link" class="cancel-post-medium-cross-link hide-if-no-js button-cancel"><?php _e( 'Cancel', 'medium' ) ?></a>
 		</p>
 	</div>
 </div>

--- a/views/form-post-box-linked.phtml
+++ b/views/form-post-box-linked.phtml
@@ -4,7 +4,7 @@
 		<a href="https://medium.com"><img class="post-medium-image post-medium-image-logo" src="<?= $data->medium_logo_url ?>"/></a>
 	</div>
 	<div id="medium-post-link">
-		<b><a href="<?= $data->medium_post->url ?>" target="_blank">View Medium post</a></b>
-		<p>Further edits to this entry will not be reflected on Medium.</p>
+		<b><a href="<?= $data->medium_post->url ?>" target="_blank"><?php _e( 'View Medium post', 'medium' ) ?></a></b>
+		<p><?php _e( 'Further edits to this entry will not be reflected on Medium.', 'medium' ) ?></p>
 	</div>
 </div>

--- a/views/form-user-profile.phtml
+++ b/views/form-user-profile.phtml
@@ -8,7 +8,7 @@
 				<p class="description">
 					<?php
 					printf(
-						_x( 'Connected to Medium as %s.', 'medium', 'Medium user profile link' ),
+						_x( 'Connected to Medium as %s.', 'Medium user profile link', 'medium' ),
 						sprintf(
 							'<a href="%s">%s</a>',
 							esc_url( $data->medium_user->url ),
@@ -21,7 +21,7 @@
 				<p class="description">
 					<?php
 					printf(
-						_x( 'You can get this from the Integration Tokens section of your %s.', 'medium', 'Medium settings link' ),
+						_x( 'You can get this from the Integration Tokens section of your %s.', 'Medium settings link', 'medium' ),
 						sprintf(
 							'<a href="https://medium.com/me/settings#integration-tokens" target="_blank">%s</a>',
 							__( 'Medium Settings', 'medium' )

--- a/views/form-user-profile.phtml
+++ b/views/form-user-profile.phtml
@@ -3,7 +3,7 @@
 	<tr>
 		<th><label for="medium_integration_token"><?php _e( 'Integration Token', 'medium' ) ?></label></th>
 		<td>
-			<input type="text" name="medium_integration_token" id="medium_integration_token" value="<?= $data->medium_user->token ?>" class="regular-text" /><br />
+			<input type="text" name="medium_integration_token" id="medium_integration_token" value="<?= $data->medium_user->token ?>" class="regular-text code" /><br />
 			<?php if ( $data->medium_user->token ) : ?>
 				<p class="description">
 					<?php

--- a/views/form-user-profile.phtml
+++ b/views/form-user-profile.phtml
@@ -1,20 +1,39 @@
-<h3 id="medium">Medium</h3>
+<h3 id="medium"><?php _e( 'Medium', 'medium' ) ?></h3>
 <table class="form-table">
 	<tr>
-		<th><label for="medium_integration_token">Integration Token</label></th>
+		<th><label for="medium_integration_token"><?php _e( 'Integration Token', 'medium' ) ?></label></th>
 		<td>
 			<input type="text" name="medium_integration_token" id="medium_integration_token" value="<?= $data->medium_user->token ?>" class="regular-text" /><br />
-			<?php
-			if ($data->medium_user->token) {
-				?><p class="description">Connected to Medium as <a href="<?= $data->medium_user->url ?>"><?= $data->medium_user->name ?></a>.</p><?php
-			} else {
-				?><p class="description">You can get this from the Integration Tokens section of your <a href="https://medium.com/me/settings#integration-tokens" target="_blank">Medium Settings</a>.</p><?php
-			}
-			?>
+			<?php if ( $data->medium_user->token ) : ?>
+				<p class="description">
+					<?php
+					printf(
+						_x( 'Connected to Medium as %s.', 'medium', 'Medium user profile link' ),
+						sprintf(
+							'<a href="%s">%s</a>',
+							esc_url( $data->medium_user->url ),
+							esc_html( $data->medium_user->name )
+						)
+					)
+					?>
+				</p>
+			<?php else : ?>
+				<p class="description">
+					<?php
+					printf(
+						_x( 'You can get this from the Integration Tokens section of your %s.', 'medium', 'Medium settings link' ),
+						sprintf(
+							'<a href="https://medium.com/me/settings#integration-tokens" target="_blank">%s</a>',
+							__( 'Medium Settings', 'medium' )
+						)
+					)
+					?>
+				</p>
+			<?php endif; ?>
 		</td>
 	</tr>
 	<tr>
-		<th><label for="medium_default_post_status">Default crosspost status</label></th>
+		<th><label for="medium_default_post_status"><?php _e( 'Default crosspost status', 'medium' ) ?></label></th>
 		<td>
 			<select name="medium_default_post_status" id="medium_default_post_status">
 				<?php
@@ -26,13 +45,12 @@
 				?>
 			</select>
 			<p class="description">
-				The default status to use when creating a post on Medium. Unlisted posts will not<br>
-				be indexed, nor distributed through Medium. Can be changed for each post.
+				<?php _e( 'The default status to use when creating a post on Medium. Unlisted posts will not be indexed, nor distributed through Medium. Can be changed for each post.', 'medium' ) ?>
 			</p>
 		</td>
 	</tr>
 	<tr>
-		<th><label for="medium_default_post_license">Default crosspost license</label></th>
+		<th><label for="medium_default_post_license"><?php _e( 'Default crosspost license', 'medium' ) ?></label></th>
 		<td>
 			<select name="medium_default_post_license" id="medium_default_post_license">
 				<?php
@@ -44,12 +62,12 @@
 				?>
 			</select>
 			<p class="description">
-				The default license to use when creating a post on Medium. Does not display any license<br>
-				information locally. Can be changed for each post.</p>
+				<?php _e( 'The default license to use when creating a post on Medium. Does not display any license information locally. Can be changed for each post.', 'medium' ) ?><br>
+			</p>
 		</td>
 	</tr>
 	<tr>
-		<th><label for="medium_default_post_cross_link">Default cross-link status</label></th>
+		<th><label for="medium_default_post_cross_link"><?php _e( 'Default cross-link status', 'medium' ) ?></label></th>
 		<td>
 			<select name="medium_default_post_cross_link" id="medium_default_post_cross_link">
 				<?php
@@ -61,8 +79,7 @@
 				?>
 			</select>
 			<p class="description">
-				Whether or not to cross-link posts between this blog and Medium. When enabled adds a <br>
-				link to the bottom of both your local post, and the Medium post. Can be changed for each post.
+				<?php _e( 'Whether or not to cross-link posts between this blog and Medium. When enabled adds a link to the bottom of both your local post, and the Medium post. Can be changed for each post.', 'medium' ) ?>
 			</p>
 		</td>
 	</tr>

--- a/views/notice-api-disabled.phtml
+++ b/views/notice-api-disabled.phtml
@@ -1,3 +1,3 @@
 <div class="error">
-	<p>The Medium API is temporarily disabled.</p>
+	<p><?php _e( 'The Medium API is temporarily disabled.', 'medium' ) ?></p>
 </div>

--- a/views/notice-connected.phtml
+++ b/views/notice-connected.phtml
@@ -1,3 +1,14 @@
 <div class="updated">
-	<p>Successfully connected to Medium as <strong><a href="<?= $data->user->url ?>"><?= $data->user->name ?></a></strong>.</p>
+	<p>
+		<?php
+		printf(
+			_x( 'Successfully connected to Medium as %s.', 'medium', 'Medium user link' ),
+			sprintf(
+				'<strong><a href="%s">%s</a></strong>',
+				esc_url( $data->user->url ),
+				esc_html( $data->user->name )
+			)
+		)
+		?>
+	</p>
 </div>

--- a/views/notice-connected.phtml
+++ b/views/notice-connected.phtml
@@ -2,7 +2,7 @@
 	<p>
 		<?php
 		printf(
-			_x( 'Successfully connected to Medium as %s.', 'medium', 'Medium user link' ),
+			_x( 'Successfully connected to Medium as %s.', 'Medium user link', 'medium' ),
 			sprintf(
 				'<strong><a href="%s">%s</a></strong>',
 				esc_url( $data->user->url ),

--- a/views/notice-invalid-token.phtml
+++ b/views/notice-invalid-token.phtml
@@ -1,3 +1,13 @@
 <div class="error">
-	<p><strong><?= $data->token ?></strong> is not a valid Medium integration token.</p>
+	<p>
+		<?php
+		printf(
+			_x( '%s is not a valid Medium integration token.', 'medium', 'Medium integration token' ),
+			sprintf(
+				'<strong>%s</strong>',
+				esc_html( $data->token )
+			)
+		)
+		?>
+	</p>
 </div>

--- a/views/notice-invalid-token.phtml
+++ b/views/notice-invalid-token.phtml
@@ -2,7 +2,7 @@
 	<p>
 		<?php
 		printf(
-			_x( '%s is not a valid Medium integration token.', 'medium', 'Medium integration token' ),
+			_x( '%s is not a valid Medium integration token.', 'Medium integration token', 'medium' ),
 			sprintf(
 				'<strong>%s</strong>',
 				esc_html( $data->token )

--- a/views/notice-published.phtml
+++ b/views/notice-published.phtml
@@ -1,15 +1,17 @@
-<div class="updated">
-	<p>
-		<?php
-		printf(
-			_x( '%s post successfully created on Medium.', 'Medium integration token', 'medium' ),
-			esc_html( $data->medium_post_statuses[ $data->medium_post->status ] )
-		);
-		printf(
-			'<a href="%s" target="_blank">%s</a>',
-			esc_url( $data->medium_post->url ),
-			__( 'View post', 'medium' )
-		);
-		?>
-	</p>
-</div>
+<?php if ( isset( $data->medium_post_statuses[ $data->medium_post->status ] ) ) : ?>
+	<div class="updated">
+		<p>
+			<?php
+			printf(
+				_x( '%s post successfully created on Medium.', 'Medium integration token', 'medium' ),
+				esc_html( $data->medium_post_statuses[ $data->medium_post->status ] )
+			);
+			printf(
+				'<a href="%s" target="_blank">%s</a>',
+				esc_url( $data->medium_post->url ),
+				__( 'View post', 'medium' )
+			);
+			?>
+		</p>
+	</div>
+<?php endif; ?>

--- a/views/notice-published.phtml
+++ b/views/notice-published.phtml
@@ -1,3 +1,15 @@
 <div class="updated">
-	<p><?= $data->medium_post_statuses[$data->medium_post->status] ?> post successfully created on Medium. <a href="<?= $data->medium_post->url ?>" target="_blank">View post</a>.</p>
+	<p>
+		<?php
+		printf(
+			_x( '%s post successfully created on Medium.', 'medium', 'Medium integration token' ),
+			esc_html( $data->medium_post_statuses[ $data->medium_post->status ] )
+		);
+		printf(
+			'<a href="%s" target="_blank">%s</a>',
+			esc_url( $data->medium_post->url ),
+			__( 'View post', 'medium' )
+		);
+		?>
+	</p>
 </div>

--- a/views/notice-published.phtml
+++ b/views/notice-published.phtml
@@ -2,7 +2,7 @@
 	<p>
 		<?php
 		printf(
-			_x( '%s post successfully created on Medium.', 'medium', 'Medium integration token' ),
+			_x( '%s post successfully created on Medium.', 'Medium integration token', 'medium' ),
 			esc_html( $data->medium_post_statuses[ $data->medium_post->status ] )
 		);
 		printf(

--- a/views/notice-something-wrong.phtml
+++ b/views/notice-something-wrong.phtml
@@ -1,3 +1,5 @@
 <div class="error">
-	<p><strong>Medium Error:</strong> <?= $data->message ?> (<?= $data->code ?>)</p>
+	<p>
+		<strong><?php _e( 'Medium Error:', 'medium' ?></strong> <?= $data->message ?> (<?= $data->code ?>)
+	</p>
 </div>


### PR DESCRIPTION
This PR makes all strings inside the `views` i18n compatible in the proper WordPress way.

I was careful to properly escape variables for output that existed in/around i18n strings, and I wrapped HTML within i18n strings separately for full RTL support.