### PR TITLE
Fix bugs causing posts to be pushed to Medium incorrectly

### DIFF
--- a/lib/medium-admin.php
+++ b/lib/medium-admin.php
@@ -136,6 +136,12 @@ class Medium_Admin {
   public static function save_post($post_id, $post) {
     if (defined('DOING_AUTOSAVE') && DOING_AUTOSAVE) return;
 
+    $allowed_post_types = (array) apply_filters('medium_allowed_post_types', array('post'));
+
+    if (!in_array(get_post_type($post_id), $allowed_post_types)) {
+      return;
+    }
+
     $medium_post = Medium_Post::get_by_wp_id($post_id);
 
     // If this post has already been sent to Medium, no need to do anything.

--- a/lib/medium-admin.php
+++ b/lib/medium-admin.php
@@ -136,15 +136,15 @@ class Medium_Admin {
   public static function save_post($post_id, $post) {
     if (defined('DOING_AUTOSAVE') && DOING_AUTOSAVE) return;
 
-    // Use the ID of the parent post if this is a post revision
-    if ($parent_id = wp_is_post_revision($post)) {
-      $post_id = $parent_id;
-    }
-
     $allowed_post_types = (array) apply_filters('medium_allowed_post_types', array('post'));
 
     if (!in_array($post->post_type, $allowed_post_types)) {
       return;
+    }
+
+    // Use the ID of the parent post if this is a post revision
+    if ($parent_id = wp_is_post_revision($post)) {
+      $post_id = $parent_id;
     }
 
     $medium_post = Medium_Post::get_by_wp_id($post_id);

--- a/lib/medium-admin.php
+++ b/lib/medium-admin.php
@@ -145,7 +145,7 @@ class Medium_Admin {
     $medium_post = Medium_Post::get_by_wp_id($post_id);
 
     // If this post has already been sent to Medium, no need to do anything.
-    if (isset($medium_post->id)) return;
+    if (!empty($medium_post->id)) return;
 
     if (isset($_REQUEST["medium-status"])) {
       $medium_post->status = $_REQUEST["medium-status"];

--- a/lib/medium-admin.php
+++ b/lib/medium-admin.php
@@ -136,15 +136,15 @@ class Medium_Admin {
   public static function save_post($post_id, $post) {
     if (defined('DOING_AUTOSAVE') && DOING_AUTOSAVE) return;
 
-    $allowed_post_types = (array) apply_filters('medium_allowed_post_types', array('post'));
-
-    if (!in_array($post->post_type, $allowed_post_types)) {
-      return;
-    }
-
     // Use the ID of the parent post if this is a post revision
     if ($parent_id = wp_is_post_revision($post)) {
       $post_id = $parent_id;
+    }
+
+    $allowed_post_types = (array) apply_filters('medium_allowed_post_types', array('post'));
+
+    if (!in_array(get_post_type($post_id), $allowed_post_types)) {
+      return;
     }
 
     $medium_post = Medium_Post::get_by_wp_id($post_id);

--- a/lib/medium-admin.php
+++ b/lib/medium-admin.php
@@ -136,14 +136,9 @@ class Medium_Admin {
   public static function save_post($post_id, $post) {
     if (defined('DOING_AUTOSAVE') && DOING_AUTOSAVE) return;
 
-    // Use the ID of the parent post if this is a post revision
-    if ($parent_id = wp_is_post_revision($post)) {
-      $post_id = $parent_id;
-    }
+    $allowed_post_types = (array) apply_filters("medium_allowed_post_types", array("post"));
 
-    $allowed_post_types = (array) apply_filters('medium_allowed_post_types', array('post'));
-
-    if (!in_array(get_post_type($post_id), $allowed_post_types)) {
+    if (!in_array($post->post_type, $allowed_post_types)) {
       return;
     }
 

--- a/lib/medium-admin.php
+++ b/lib/medium-admin.php
@@ -136,6 +136,11 @@ class Medium_Admin {
   public static function save_post($post_id, $post) {
     if (defined('DOING_AUTOSAVE') && DOING_AUTOSAVE) return;
 
+    // Use the ID of the parent post if this is a post revision
+    if ($parent_id = wp_is_post_revision($post)) {
+      $post_id = $parent_id;
+    }
+
     $allowed_post_types = (array) apply_filters('medium_allowed_post_types', array('post'));
 
     if (!in_array($post->post_type, $allowed_post_types)) {
@@ -145,7 +150,7 @@ class Medium_Admin {
     $medium_post = Medium_Post::get_by_wp_id($post_id);
 
     // If this post has already been sent to Medium, no need to do anything.
-    if (!empty($medium_post->id)) return;
+    if ($medium_post->id) return;
 
     if (isset($_REQUEST["medium-status"])) {
       $medium_post->status = $_REQUEST["medium-status"];

--- a/lib/medium-admin.php
+++ b/lib/medium-admin.php
@@ -138,7 +138,7 @@ class Medium_Admin {
 
     $allowed_post_types = (array) apply_filters('medium_allowed_post_types', array('post'));
 
-    if (!in_array(get_post_type($post_id), $allowed_post_types)) {
+    if (!in_array($post->post_type, $allowed_post_types)) {
       return;
     }
 

--- a/lib/medium-admin.php
+++ b/lib/medium-admin.php
@@ -145,7 +145,7 @@ class Medium_Admin {
     $medium_post = Medium_Post::get_by_wp_id($post_id);
 
     // If this post has already been sent to Medium, no need to do anything.
-    if ($medium_post->id) return;
+    if (isset($medium_post->id)) return;
 
     if (isset($_REQUEST["medium-status"])) {
       $medium_post->status = $_REQUEST["medium-status"];


### PR DESCRIPTION
@majelbstoat Fixes #17 and #23

Adds a filter for allowed post types array, only allow `post` by default.

This will safely ignore all the other [default post types](https://codex.wordpress.org/Post_Types#Default_Post_Types).