### PR TITLE
Make activation safer, fallback to a default publication

### DIFF
--- a/lib/medium-admin.php
+++ b/lib/medium-admin.php
@@ -2,10 +2,10 @@
 // Copyright 2015 Medium
 // Licensed under the Apache License, Version 2.0.
 
-require_once(MEDIUM_PLUGIN_DIR . "lib/medium-post.php");
-require_once(MEDIUM_PLUGIN_DIR . "lib/medium-publication.php");
-require_once(MEDIUM_PLUGIN_DIR . "lib/medium-user.php");
-require_once(MEDIUM_PLUGIN_DIR . "lib/medium-view.php");
+include_once(MEDIUM_PLUGIN_DIR . "lib/medium-post.php");
+include_once(MEDIUM_PLUGIN_DIR . "lib/medium-publication.php");
+include_once(MEDIUM_PLUGIN_DIR . "lib/medium-user.php");
+include_once(MEDIUM_PLUGIN_DIR . "lib/medium-view.php");
 
 define("NO_PUBLICATION", -1);
 
@@ -282,7 +282,7 @@ class Medium_Admin {
       }
       if (!$medium_post->publication_id) {
         // Default to none.
-        $medium_post->publication_id = $medium_user->default_publication_id;
+        $medium_post->publication_id = $medium_user->default_publication_id ?: NO_PUBLICATION;
       }
 
       $publication_options = self::_get_user_publication_options($medium_user);

--- a/lib/medium-site.php
+++ b/lib/medium-site.php
@@ -2,8 +2,8 @@
 // Copyright 2015 Medium
 // Licensed under the Apache License, Version 2.0.
 
-require_once(MEDIUM_PLUGIN_DIR . "lib/medium-post.php");
-require_once(MEDIUM_PLUGIN_DIR . "lib/medium-view.php");
+include_once(MEDIUM_PLUGIN_DIR . "lib/medium-post.php");
+include_once(MEDIUM_PLUGIN_DIR . "lib/medium-view.php");
 
 class Medium_Site {
 

--- a/medium.php
+++ b/medium.php
@@ -1,12 +1,12 @@
 <?php
 /**
  * @package Medium
- * @version 1.0.1
+ * @version 1.1.1
  */
 /*
 Plugin Name: Medium
 Description: Publish posts automatically from your blog to a Medium profile.
-Version: 1.1
+Version: 1.1.1
 Author: A Medium Corporation
 Author URI: https://medium.com
 License: Apache
@@ -20,7 +20,7 @@ if (!function_exists("add_action")) {
   exit;
 }
 
-define("MEDIUM_VERSION", "1.1");
+define("MEDIUM_VERSION", "1.1.1");
 define("MEDIUM_PLUGIN_DIR", plugin_dir_path(__FILE__));
 define("MEDIUM_PLUGIN_URL", plugin_dir_url(__FILE__));
 

--- a/readme.txt
+++ b/readme.txt
@@ -36,6 +36,10 @@ Any modifications you make to a post after you have sent the post to Medium will
 
 == Changelog ==
 
+= Medium 1.1.1 =
+* Fixed: Missing publication Id for publishing after upgrade.
+* Fixed: Make upgrading safer if WordPress sandboxing doesn't catch activation errors.
+
 = Medium 1.1 =
 * New: Publish a post directly into a publication.
 * New: Posts are sent to Medium with the same publish date as on WordPress.


### PR DESCRIPTION
Hello @kylehg, @mikkot, 

Please review the following commits I made in branch 'jamie-missing-publication'.

5e8181d4bde5388a8e283e46c0efa4898fdd9b03 (2015-11-23 10:43:31 -0800)
Make activation safer, fallback to a default publication

R=@kylehg
R=@mikkot
CC=@caramev