### PR TITLE
Process shortcodes before cross-posting

### DIFF
--- a/lib/medium-admin.php
+++ b/lib/medium-admin.php
@@ -949,7 +949,7 @@ class Medium_Admin {
    */
   private static function _prepare_content($post) {
     // Add paragraph tags.
-    $post_content = wpautop($post->post_content);
+    $post_content = do_shortcode(wpautop($post->post_content));
 
     // Best effort. Regex parsing of HTML is a bad idea, generally, but including
     // a full parser just for this case is over the top. This will match things


### PR DESCRIPTION
Hello @mikkot, @kylehg, 

Please review the following commits I made in branch 'jamie-shortcode'.

03d04c9101877a551ac0bcdf949f1882f86fcb00 (2015-12-07 23:30:16 +0000)
Process shortcodes before cross-posting

Turns out we can do this "safely" because the shortcode addition that
the plugin does is on the site side of things, not the admin side. "Safely", because
short codes can generate arbitrary HTML, which the API may then reject... but, we'll
cross that when we come to it.

R=@mikkot
R=@kylehg