### PR TITLE
Don't use array literals

### DIFF
--- a/lib/medium-admin.php
+++ b/lib/medium-admin.php
@@ -296,7 +296,7 @@ class Medium_Admin {
       "draft" => 0,
       "public" => 0
     );
-    $rows = [];
+    $rows = array();
 
     // Define a header row that describes the migration strategy.
     $rows[] = "(0, $fallback_user_id, '$publication_id', '$post_status', '$post_license', 0)";


### PR DESCRIPTION
Hello @mikkot, @majelbstoat, 

Please review the following commits I made in branch 'kyle-arr'.

fd2073275f19d0f92135327e54580913643ce207 (2015-12-08 09:16:32 -0800)
Don't use array literals

R=@mikkot
R=@majelbstoat