### PR TITLE
Prevent dedupe of tags from ruining JSON output

### DIFF
--- a/lib/medium-admin.php
+++ b/lib/medium-admin.php
@@ -737,7 +737,7 @@ class Medium_Admin {
         $slugs[] = $tag->name;
       }
     }
-    $tags = array_unique(array_merge($slugs, $tags));
+    $tags = array_values(array_unique(array_merge($slugs, $tags)));
 
     if (class_exists('CoAuthors_Guest_Authors')) {
       // Handle guest-authors if the CoAuthors Plus plugin is installed.


### PR DESCRIPTION
Hello @majelbstoat, @mikkot, 

Please review the following commits I made in branch 'kyle-arr'.

383dc3c3aaf5dc42a4ff78258e5cd3c2512c2082 (2015-12-08 10:39:40 -0800)
Prevent dedupe of tags from ruining JSON output

R=@majelbstoat
R=@mikkot