### PR TITLE
Strip HTML tags from post titles when cross-posting.

### DIFF
--- a/lib/medium-admin.php
+++ b/lib/medium-admin.php
@@ -751,7 +751,7 @@ class Medium_Admin {
 
     $permalink = get_permalink($post->ID);
     $content = Medium_View::render("content-rendered-post", array(
-      "title" => $post->post_title,
+      "title" => strip_tags($post->post_title),
       "content" => self::_prepare_content($post),
       "cross_link" => $medium_post->cross_link == "yes",
       "site_name" => get_bloginfo('name'),
@@ -760,7 +760,7 @@ class Medium_Admin {
     ), true);
 
     $body = array(
-      "title" => $post->post_title,
+      "title" => strip_tags($post->post_title),
       "content" => $content,
       "tags" => $tags,
       "contentFormat" => "html",


### PR DESCRIPTION
Hello @majelbstoat, @mikkot, @kylehg, 

Please review the following commits I made in branch 'chad-fix-strip-tags-in-titles'.

49af060ab3fbb44f3e72449e9f896e29a33ff53d (2016-02-15 16:57:00 -0800)
Strip HTML tags from post titles when cross-posting.
Fixes https://github.com/Medium/medium-wordpress-plugin/issues/66

R=@majelbstoat
R=@mikkot
R=@kylehg