### PR TITLE
Add the returned content type, and the body of the response in the exception.

### DIFF
--- a/lib/medium-admin.php
+++ b/lib/medium-admin.php
@@ -1054,7 +1054,7 @@ class Medium_Admin {
     }
 
     if (false === strpos($content_type, "json")) {
-      throw new Exception(__("Unexpected response format.", "medium"), $code);
+      throw new Exception(sprintf(__("Unexpected response format: %s - %s", "medium"), $content_type, $body), $code);
     }
 
     $payload = json_decode($body);


### PR DESCRIPTION
Hello @majelbstoat, @mikkot, @kylehg, 

Please review the following commits I made in branch 'chad-better-exception-message'.

9e98060af9a93004d67dbf9ad129f500c6526ce7 (2016-03-07 12:45:37 -0800)
Add the returned content type, and the body of the response in the exception.

R=@majelbstoat
R=@mikkot
R=@kylehg