### PR TITLE
Convert post_date to UTC time.

### DIFF
--- a/lib/medium-admin.php
+++ b/lib/medium-admin.php
@@ -767,7 +767,7 @@ class Medium_Admin {
       "canonicalUrl" => $permalink,
       "license" => $medium_post->license,
       "publishStatus" => $medium_post->status,
-      "publishedAt" => mysql2date('c', $post->post_date),
+      "publishedAt" => mysql2date('c', $post->post_date_gmt),
       "notifyFollowers" => $medium_post->follower_notification == "yes"
     );
     $data = json_encode($body);


### PR DESCRIPTION
Hello @majelbstoat, @mikkot, @kylehg, 

Please review the following commits I made in branch 'chad-fix-publishedAt-bug'.

5695914efca677ed11bd6e29d76de41bd29936c2 (2016-03-12 21:16:31 -0800)
Convert post_date to UTC time.
Fixes https://github.com/Medium/medium-wordpress-plugin/issues/60

R=@majelbstoat
R=@mikkot
R=@kylehg