### PR TITLE
Use post_date_gmt, but fallback to post_date if GMT is not set.

### DIFF
--- a/lib/medium-admin.php
+++ b/lib/medium-admin.php
@@ -767,7 +767,7 @@ class Medium_Admin {
       "canonicalUrl" => $permalink,
       "license" => $medium_post->license,
       "publishStatus" => $medium_post->status,
-      "publishedAt" => mysql2date('c', $post->post_date_gmt),
+      "publishedAt" => mysql2date('c', isset($post->post_date_gmt) ? $post->post_date_gmt : $post->post_date),
       "notifyFollowers" => $medium_post->follower_notification == "yes"
     );
     $data = json_encode($body);


### PR DESCRIPTION
Hello @amyquispe, @mikkot, @majelbstoat, 

Please review the following commits I made in branch 'chad-post-date-gmt'.

5f26ea5f86f1db816a483fe20f80ebc2b8076e17 (2016-04-20 15:59:25 -0400)
Use post_date_gmt, but fallback to post_date if GMT is not set.
Fixes https://github.com/Medium/medium-wordpress-plugin/issues/75

R=@amyquispe
R=@mikkot
R=@majelbstoat