### PR TITLE
Do not prepend featured image if post_content starts with <img>

### DIFF
--- a/lib/medium-admin.php
+++ b/lib/medium-admin.php
@@ -969,7 +969,12 @@ class Medium_Admin {
    */
   private static function _prepare_content($post) {
     if (function_exists('has_post_thumbnail') && has_post_thumbnail($post)) {
-      $post_content = sprintf('<img src="%s" /><br />%s', get_the_post_thumbnail_url($post), do_shortcode(wpautop($post->post_content)));
+      // If $post->post_content starts with an <img> tag, do not use the featured image
+      if (strpos($post->post_content, "<img") != 0) {
+        $post_content = sprintf('<img src="%s" /><br />%s', get_the_post_thumbnail_url($post), do_shortcode(wpautop($post->post_content)));
+      } else {
+        $post_content = do_shortcode(wpautop($post->post_content));
+      }
     } else {
       $post_content = do_shortcode(wpautop($post->post_content));
     }


### PR DESCRIPTION
Hello @amyquispe, @mikkot, @kylehg, 

Please review the following commits I made in branch 'chad-fix-dup-images'.

713ff7f03adc00908d94a491800934fce8369705 (2016-04-28 11:11:57 -0400)
Do not prepend featured image if post_content starts with <img>
Fixes https://github.com/Medium/medium-wordpress-plugin/issues/81

R=@amyquispe
R=@mikkot
R=@kylehg