### PR TITLE
if wp_get_post_terms returns a WP_Error, try wp_get_post_tags()

### DIFF
--- a/lib/medium-admin.php
+++ b/lib/medium-admin.php
@@ -735,6 +735,10 @@ class Medium_Admin {
    */
   public static function cross_post($post, $medium_post, $medium_user) {
     $tag_data = wp_get_post_terms($post->ID, array("post_tag", "slug"));
+    // Use wp_get_post_tags() if WP_Error returned
+    if (is_wp_error($tag_data)) {
+      $tag_data = wp_get_post_tags($post->ID);
+    }
     $tags = array();
     $slugs = array();
     foreach ($tag_data as $tag) {


### PR DESCRIPTION
Hello @amyquispe, @mikkot, @kylehg, 

Please review the following commits I made in branch 'chad-fix-invalid-taxonomy'.

7cbeeff0102346864ad8e95576eac1ad72cca93f (2016-04-28 11:17:39 -0400)
if wp_get_post_terms returns a WP_Error, try wp_get_post_tags()
Fixes https://github.com/Medium/medium-wordpress-plugin/issues/80

R=@amyquispe
R=@mikkot
R=@kylehg