### PR TITLE
Use wp_get_post_tags() if wp_get_post_terms() returns an empty array.

### DIFF
--- a/lib/medium-admin.php
+++ b/lib/medium-admin.php
@@ -735,8 +735,8 @@ class Medium_Admin {
    */
   public static function cross_post($post, $medium_post, $medium_user) {
     $tag_data = wp_get_post_terms($post->ID, array("post_tag", "slug"));
-    // Use wp_get_post_tags() if WP_Error returned
-    if (is_wp_error($tag_data)) {
+    // Use wp_get_post_tags() if WP_Error or empty array returned
+    if (!count($tag_data) || is_wp_error($tag_data)) {
       $tag_data = wp_get_post_tags($post->ID);
     }
     $tags = array();


### PR DESCRIPTION
Hello @amyquispe, @mikkot, @kylehg, 

Please review the following commits I made in branch 'chad-look-for-tags'.

a35d834129bdd42c613071708b0306564df20c52 (2016-04-29 09:22:57 -0400)
Use wp_get_post_tags() if wp_get_post_terms() returns an empty array.
Fixes https://github.com/Medium/medium-wordpress-plugin/issues/85

R=@amyquispe
R=@mikkot
R=@kylehg