### PR TITLE
Use the not identical operator to check if a post starts with an <img> tag.

### DIFF
--- a/lib/medium-admin.php
+++ b/lib/medium-admin.php
@@ -986,7 +986,7 @@ class Medium_Admin {
   private static function _prepare_content($post) {
     if (function_exists('has_post_thumbnail') && has_post_thumbnail($post)) {
       // If $post->post_content starts with an <img> tag, do not use the featured image
-      if (strpos($post->post_content, "<img") != 0) {
+      if (strpos($post->post_content, "<img") !== 0) {
         $post_content = sprintf('<img src="%s" /><br />%s', get_the_post_thumbnail_url($post), do_shortcode(wpautop($post->post_content)));
       } else {
         $post_content = do_shortcode(wpautop($post->post_content));


### PR DESCRIPTION
Hello @amyquispe, @kylehg, @mikkot, 

Please review the following commits I made in branch 'chad-fix-featured-images'.

73ce1773c46d9116c847cc8a006b340fd75b46da (2016-06-06 20:14:04 -0700)
Use the not identical operator to check if a post starts with an <img> tag.
Fixes https://github.com/Medium/medium-wordpress-plugin/issues/97

R=@amyquispe
R=@kylehg
R=@mikkot