### PR TITLE
set post title as "untitled" if no title is set

### DIFF
--- a/lib/medium-admin.php
+++ b/lib/medium-admin.php
@@ -764,6 +764,12 @@ class Medium_Admin {
       }
     }
 
+    // API does not cross post when missing a title. Set as "untitled"
+    // if the post is missing a post title.
+    if (!isset($post->post_title) || strlen($post->post_title) === 0) {
+      $post->post_title = "untitled";
+    }
+
     $permalink = get_permalink($post->ID);
     $content = Medium_View::render("content-rendered-post", array(
       "title" => strip_tags($post->post_title),


### PR DESCRIPTION
Hello @amyquispe, @mikkot, 

Please review the following commits I made in branch 'huckphin/missing-post-title'.

98a4a512b73641cd3840b8bb76969f21084a00aa (2016-06-16 16:10:14 -0700)
set post title as "untitled" if no title is set
Fixes https://github.com/Medium/medium-wordpress-plugin/issues/96

R=@amyquispe
R=@mikkot