### PR TITLE
if post_date is within fifteen minutes of current time, use Medium time

### DIFF
--- a/lib/medium-admin.php
+++ b/lib/medium-admin.php
@@ -815,6 +815,14 @@ class Medium_Admin {
       "publishedAt" => mysql2date('c', isset($post->post_date_gmt) ? $post->post_date_gmt : $post->post_date),
       "notifyFollowers" => $medium_post->follower_notification == "yes"
     );
+    // cannot compare wordpress time to medium time
+    // if the $post_date is within 15 minutes, do not
+    // use 'publishedAt', just use the server time
+    // fixes https://github.com/Medium/medium-wordpress-plugin/issues/106
+    $post_date_ts = mysql2date('U', isset($post->post_date_gmt) ? $post->post_date_gmt : $post->post_date);
+    if (abs(mktime() - mysql2date('U')) < 900) {
+      unset($body["publishedAt"]);
+    }
     $data = json_encode($body);
 
     if ($medium_post->publication_id != NO_PUBLICATION) {


### PR DESCRIPTION
Hello @amyquispe, @benmedium, @mikkot, 

Please review the following commits I made in branch 'huckphin/fix-cross-post'.

e77628e2b9d19832800ec8c69e737b914ac303a1 (2016-07-28 13:50:07 -0700)
if post_date is within fifteen minutes of current time, use Medium time
There were reports of publishing with a cross-post failing. It turns out
that if you are even a second ahead of the Medium servers, the post will
fail to cross-post due to "posting in the future". If the post_date is
within 15 minutes of current time, remove the "publishedAt" attribute in
the POST body, and just use Medium server time for the actual post datetime.

Fixes https://github.com/Medium/medium-wordpress-plugin/issues/106

R=@amyquispe
R=@benmedium
R=@mikkot