### PR TITLE
Add div and classes to cross-link output

### DIFF
--- a/views/content-cross-linked.phtml
+++ b/views/content-cross-linked.phtml
@@ -1,4 +1,5 @@
-<hr>
+<hr class="medium-cross-link-hr">
+<div class="medium-cross-link">
 <p>
   <em>
   <?php
@@ -7,3 +8,4 @@
   ?>
   </em>
 </p>
+</div>

--- a/views/content-rendered-post.phtml
+++ b/views/content-rendered-post.phtml
@@ -10,7 +10,8 @@ if ($data->byline) {
 echo $data->content;
 if ($data->cross_link) {
 	?>
-	<hr>
+	<hr class="medium-cross-link-hr">
+	<div class="medium-cross-link">
 	<p>
 		<em>
 			<?php
@@ -19,5 +20,6 @@ if ($data->cross_link) {
 		  ?>
 		</em>
 	</p>
+	</div>
 	<?php
 }


### PR DESCRIPTION
Currently this plugin just adds a plain `<hr>` and `<p><em><a>` to the_content() output; I'd like to have some classes associated with those elements in order to style them per site.  

* added a class to `<hr>` output
* added a div wrapper with class around the plain `<p><em>` output
